### PR TITLE
Docker images v1.0

### DIFF
--- a/examples/docker-1/yane.yml
+++ b/examples/docker-1/yane.yml
@@ -1,22 +1,27 @@
 network:
   name: docker-1
-  version: 1.0
+  version: 1.2
   hosts:
     -
       name: obi
       mode: docker
+      image: default
     -
       name: vader
       mode: docker
+      image: default
     -
       name: luke
       mode: docker
+      image: ubuntu
     -
       name: rey
       mode: docker
+      image: alpine
     -
       name: ren
       mode: docker
+      image: alpine
 
   bridges:
     -

--- a/yane
+++ b/yane
@@ -66,12 +66,13 @@ declare -A hostNum              # Array of host numbers : 0 1, ...
 declare -A hostName             # Array of host names
 declare -A hostMode             # Array of host mode
 declare -A hostFiles            # Array of host FS
+declare -A hostDockerImage            # Array of host image
 declare -A consHost             # Array of hosts to run console on
 declare -A p2pLinks             # Array of p2p links
 declare -A interfaces           # Array of known interfaces
 declare -A dumpIf               # Array of interface to snoop
 declare -A modules              # Array o loaded modules
-declare -A bridgeName   	# Array of interfaces indexed by bridges name
+declare -A bridgeName   	      # Array of interfaces indexed by bridges name
 declare -A bridgeInterfaces     # Array of interfaces indexed by bridges name
 
 FIFO_ROOT=/tmp/nssi
@@ -327,7 +328,7 @@ createHosts () {
     do
       ht=${hostMode[$hn]}
       logMessage DEB "Creating host '${SESSION_ID}_$hn' (type $ht)"
-      createHost_${hostMode[$hn]} ${SESSION_ID}_$hn
+      createHost_${hostMode[$hn]} ${SESSION_ID}_$hn ${hostDockerImage[$hn]}
    done
 }
 

--- a/yane_module_docker
+++ b/yane_module_docker
@@ -2,15 +2,23 @@
 #===============================================================================
 # Docker helper functions
 #===============================================================================
+# Default docker image :
+DEFAULT_IMAGE="alpine:latest"
+
 #-------------------------------------------------------------------------------
 # create host
 #    $1 : hostname
+#    $2 : image
 #-------------------------------------------------------------------------------
 createHost_docker () {
-  logMessage LOG "Creating docker container $1"
 
-  $DOCKER create -it --name $1 --hostname $1 --network none --cap-add NET_ADMIN\
-    alpine:latest
+  if [ "$2" == "default" ]; then
+    logMessage LOG "Creating docker container $1 from $DEFAULT_IMAGE"
+    $DOCKER create -it --name $1 --hostname $1 --network none --privileged $DEFAULT_IMAGE
+  else #Warning should verify that $2 is a valid image
+    logMessage LOG "Creating docker container $1 from $2"
+    $DOCKER create -it --name $1 --hostname $1 --network none --privileged $2
+  fi
 }
 
 #-------------------------------------------------------------------------------

--- a/yane_module_yaml
+++ b/yane_module_yaml
@@ -67,13 +67,26 @@ buildNetworkFromFile_yaml () {
    # Parse the config file
    eval $(parse_yaml $1) 2> /dev/null
 
+   # Verify that the number of images correspond to the number of dockers
+   isNbDockersValid
+
    # Build the host lists
+   id_img=0
    for idx in ${!network_hosts__name[@]}
    do
       hostName["${network_hosts__name[$idx]}"]="${network_hosts__name[$idx]}" # a bit useless, I know
       hostNum["${network_hosts__name[$idx]}"]=$idx
       hostMode["${network_hosts__name[$idx]}"]=${network_hosts__mode[$idx]}
       hostFiles["${network_hosts__name[$idx]}"]=${network_hosts__files[$idx]}
+
+      # Create docker images list `hostDockerImage`
+      # `none` images is use for no docker hosts
+      if [ "${network_hosts__mode[$idx]}" != "docker" ]; then
+        hostDockerImage["${network_hosts__name[$idx]}"]="none"
+      else
+        hostDockerImage["${network_hosts__name[$idx]}"]=${network_hosts__image[$id_img]}
+        (( id_img++ ))
+      fi
    done
 
    # Build the console list
@@ -118,4 +131,26 @@ buildNetworkFromFile_yaml () {
           logMessage ERR "Cannot snoop on unknown host '$hn' ..."
       fi
    done
+}
+
+#-------------------------------------------------------------------------------
+# Read the number of docker specified in yane.yml and exit if there are
+# enough or too much images defined.
+#-------------------------------------------------------------------------------
+isNbDockersValid () {
+  nbDocker=0
+  for mode in ${network_hosts__mode[@]}
+  do
+    if [ $mode = "docker" ]; then
+      (( nbDocker++ ))
+    fi
+  done
+
+  if [ $nbDocker -lt ${#network_hosts__image[@]} ]; then
+    logMessage ERR "Only dockers must have an image..."
+    exit
+  elif [ $nbDocker -gt ${#network_hosts__image[@]} ]; then
+    logMessage ERR "Too much dockers and not enough images..."
+    exit
+  fi
 }


### PR DESCRIPTION
# Fusion de la branche option_images
Fonctionnalité image docker version 1.0. 
* Manque la doc qui devrait arriver dans les prochains commit

**Exemple pour spécifier l'image d'un docker :**
```yaml
-
name: leia
mode: docker
images: ubuntu
-
```